### PR TITLE
Fix issue where text stops being loaded after setting a support card filter.

### DIFF
--- a/translations/mdb/text_data/294.json
+++ b/translations/mdb/text_data/294.json
@@ -36,7 +36,7 @@
         "hash": "f0be2f1177a5031797bb6c62f06c797d4de44d0dd3597790682671499b4fb52b"
     },
     "10": {
-        "text": "Initial Stamina\\Up",
+        "text": "Initial Stamina\\nUp",
         "hash": "6f9f56dee2faef0cebaee274171f8da10aeade3fe119f1dd9e5846314663c6bd"
     },
     "11": {


### PR DESCRIPTION
Typo caused the issue

![bleh](https://static1.cbrimages.com/wordpress/wp-content/uploads/2023/02/youre-under-arrest-1.jpeg)