### PR TITLE
Update NumPy version for compatibility with newer Python versions.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ fsspec==2023.6.0
 h11==0.14.0
 idna==3.4
 lz4==4.3.2
-numpy==1.25.2
+numpy==1.26.4
 outcome==1.3.0.post0
 pandas==2.0.3
 pathvalidate==3.1.0


### PR DESCRIPTION
Old version of numpy was giving error on Python 3.12 due to the removal of the pkgutil.ImpImporter class. Updating numpy to the latest version fixes this