### PR TITLE
Also ignore tl-en as symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ translations_backup/
 dist/
 dump/
 *.csv
-tl-en/
+/tl-en
 jikkyo_templates.json


### PR DESCRIPTION
"Soft" symlinks are treated as files and not matched by the current pattern.
This also changes it to a relative ignore, so only the entry in root will be ignored, just in case. Maybe that's not wanted though.